### PR TITLE
fix prefixing for overview template

### DIFF
--- a/contrib/templates/default/overview.mustache
+++ b/contrib/templates/default/overview.mustache
@@ -16,9 +16,9 @@ paramters:
   <tbody>
     {{#overview}}
       <tr>
-        <td><a href="{{Prefix}}{{Board}}-0.html">{{Board}}</td>
+        <td><a href="{{prefix}}{{Board}}-0.html">{{Board}}</td>
         <td>{{Date}}</td>
-        <td><a href="{{PostURL}}">{{Truncate.Subject}}</a></td>
+        <td><a href="{{prefix}}{{PostURL}}">{{Truncate.Subject}}</a></td>
       </tr>
     {{/overview}}
   </tbody>


### PR DESCRIPTION
This should make i2p.rocks work like it's supposed to.