### PR TITLE
explicitly set height and width attrs to avoid jumping beans

### DIFF
--- a/contrib/js/nntpchan/banner.js
+++ b/contrib/js/nntpchan/banner.js
@@ -7,6 +7,8 @@ function nntpchan_inject_banners(elem, prefix) {
   var e = document.createElement("img");
   e.src = banner;
   e.id = "nntpchan_banner";
+  e.height = "150";
+  e.width = "300";
   elem.appendChild(e);
 }
 


### PR DESCRIPTION
Pages will jump if image size isn't explicitly declared.