### PR TITLE
srnd: ensure clean XOVER output

### DIFF
--- a/contrib/backends/srndv2/src/srnd/nntp.go
+++ b/contrib/backends/srndv2/src/srnd/nntp.go
@@ -550,6 +550,13 @@ func (self *nntpConnection) checkMIMEHeaderNoAuth(daemon *NNTPDaemon, hdr textpr
 	return
 }
 
+var overReplacer = strings.NewReplacer("\t", " ", "\n", " ", "\r", "", "\000", "")
+
+// safeOver cleans string for OVER/XOVER output
+func safeOver(s string) string {
+	return strings.TrimSpace(overReplacer.Replace(s))
+}
+
 func (self *nntpConnection) handleLine(daemon *NNTPDaemon, code int, line string, conn *textproto.Conn) (err error) {
 	parts := strings.Split(line, " ")
 	var msgid string
@@ -914,7 +921,25 @@ func (self *nntpConnection) handleLine(daemon *NNTPDaemon, code int, line string
 						for _, model := range models {
 							if model != nil {
 								if err == nil {
-									io.WriteString(dw, fmt.Sprintf("%.6d\t%s\t\"%s\" <%s@%s>\t%s\t%s\t%s\r\n", model.NNTPID(), model.Subject(), model.Name(), model.Name(), model.Frontend(), model.Date(), model.MessageID(), model.Reference()))
+									/*
+									The first 8 fields MUST be the following, in order:
+									     "0" or article number (see below)
+									     Subject header content
+									     From header content
+									     Date header content
+									     Message-ID header content
+									     References header content
+									     :bytes metadata item
+									     :lines metadata item
+									*/
+									fmt.Fprintf(dw,
+										"%.6d\t%s\t\"%s\" <%s@%s>\t%s\t%s\t%s\r\n",
+										model.NNTPID(),
+										safeOver(model.Subject()),
+										safeOver(model.Name()), safeOver(model.Name()), safeOver(model.Frontend()),
+										safeOver(model.Date()),
+										safeOver(model.MessageID()),
+										safeOver(model.Reference()))
 								}
 							}
 						}


### PR DESCRIPTION
after debugging XOVER output of 21.3.37.5 with `cat -t` I noticed that some rows contain newlines...