### PR TITLE
srnd: use some of headers from outer message

### DIFF
--- a/contrib/backends/srndv2/src/srnd/message.go
+++ b/contrib/backends/srndv2/src/srnd/message.go
@@ -262,7 +262,7 @@ func (self *nntpArticle) Pubkey() string {
 }
 
 func (self *nntpArticle) MessageID() (msgid string) {
-	for _, h := range []string{"Message-ID", "Messageid", "MessageID", "Message-Id"} {
+	for _, h := range []string{"Message-ID", "Message-Id"} {
 		mid := self.headers.Get(h, "")
 		if mid != "" {
 			msgid = string(mid)
@@ -485,7 +485,7 @@ func (self *nntpArticle) WriteBody(wr io.Writer, limit int64) (err error) {
 // verify a signed message's body
 // innerHandler must close reader when done
 // returns error if one happens while verifying article
-func verifyMessageSHA512(pk, sig string, body io.Reader, innerHandler func(map[string][]string, io.Reader)) (err error) {
+func verifyMessageSHA512(pk, sig string, body io.Reader, innerHandler func(ArticleHeaders, io.Reader)) (err error) {
 	log.Println("unwrapping signed message from", pk)
 	pk_bytes := unhex(pk)
 	sig_bytes := unhex(sig)
@@ -497,7 +497,7 @@ func verifyMessageSHA512(pk, sig string, body io.Reader, innerHandler func(map[s
 		r := bufio.NewReader(hdr_reader)
 		msg, err := readMIMEHeader(r)
 		if err == nil {
-			innerHandler(msg.Header, msg.Body)
+			innerHandler(ArticleHeaders(msg.Header), msg.Body)
 		}
 		hdr_reader.Close()
 	}(pr)
@@ -520,7 +520,7 @@ func verifyMessageSHA512(pk, sig string, body io.Reader, innerHandler func(map[s
 	return
 }
 
-func verifyMessageBLAKE2B(pk, sig string, body io.Reader, innerHandler func(map[string][]string, io.Reader)) (err error) {
+func verifyMessageBLAKE2B(pk, sig string, body io.Reader, innerHandler func(ArticleHeaders, io.Reader)) (err error) {
 	log.Println("unwrapping signed message from", pk)
 	pk_bytes := unhex(pk)
 	sig_bytes := unhex(sig)
@@ -532,7 +532,7 @@ func verifyMessageBLAKE2B(pk, sig string, body io.Reader, innerHandler func(map[
 		r := bufio.NewReader(hdr_reader)
 		msg, err := readMIMEHeader(r)
 		if err == nil {
-			innerHandler(msg.Header, msg.Body)
+			innerHandler(ArticleHeaders(msg.Header), msg.Body)
 		}
 		hdr_reader.Close()
 	}(pr)

--- a/contrib/backends/srndv2/src/srnd/store.go
+++ b/contrib/backends/srndv2/src/srnd/store.go
@@ -700,7 +700,14 @@ func read_message_body(body io.Reader, hdr map[string][]string, store ArticleSto
 		}
 		// process inner body
 		// verify message
-		f := func(h map[string][]string, innerBody io.Reader) {
+		f := func(h ArticleHeaders, innerBody io.Reader) {
+			// override some of headers of inner message
+			msgid := nntp.MessageID()
+			if msgid != "" {
+				h.Set("Message-Id", msgid)
+			}
+			h.Set("Path", nntp.headers.Get("Path", ""))
+			h.Set("X-Pubkey-Ed25519", pk)
 			// handle inner message
 			e := read_message_body(innerBody, h, store, nil, true, callback)
 			if e != nil {


### PR DESCRIPTION
for signed messages, override some of inner message headers from outer message.
Message-ID and X-PubKey-Ed25519 may not be present, Path is very unlikely to be up to date, and srnd uses headers of only inner msg for its stuff (imo bad idea), this sorta makes it a little bit less bad and makes it work with articles which don't have these headers in inner message.