### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/contrib/backends/srndv2/src/srnd/vendor/golang.org/x/text/internal/number/ftoa.go
+++ b/contrib/backends/srndv2/src/srnd/vendor/golang.org/x/text/internal/number/ftoa.go
@@ -432,17 +432,3 @@ func fmtB(dst []byte, neg bool, mant uint64, exp int, flt *floatInfo) []byte {
 
 	return dst
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 